### PR TITLE
Many changes/fixes to Motion Profile Command

### DIFF
--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -2,7 +2,6 @@ package frc.robot;
 
 import frc.robot.commands.SwerveDriveWithMotionProfile;
 import harkerrobolib.wrappers.XboxGamepad;
-import jaci.pathfinder.Pathfinder;
 import jaci.pathfinder.Waypoint;
 /**
  * Contains controllers (Xbox or DDR) and their button bindings
@@ -22,12 +21,6 @@ public class OI {
     
     public static final double XBOX_JOYSTICK_DEADBAND = 0.1;
 
-    Waypoint[] points = new Waypoint[] {
-        new Waypoint(-4, -1, Pathfinder.d2r(0)),      // Waypoint @ x=-4, y=-1, exit angle=-45 degrees
-        new Waypoint(-3, -1, 0),                        // Waypoint @ x=-2, y=-2, exit angle=0 radians
-        new Waypoint(-2, -1, 0)                           // Waypoint @ x=0, y=0,   exit angle=0 radians
-    };
-
     private XboxGamepad operatorGamepad;
     private XboxGamepad driverGamepad;
 
@@ -38,7 +31,16 @@ public class OI {
     }
 
     public void initBindings() {
-        OI.getInstance().getDriverGamepad().getButtonY().whenPressed(new SwerveDriveWithMotionProfile(points));
+        Waypoint[] points = new Waypoint[] {
+            new Waypoint(0, 0, Math.toDegrees(0)),
+            new Waypoint(0, 1, Math.toDegrees(30))
+        };
+
+        int timeDur = 10; //ms between each segment
+
+        // OI.getInstance().getDriverGamepad().getUpDPadButton().whenPressed(
+        //         new SwerveDriveWithMotionProfile(points, timeDur)
+        // );
     }
 
     public XboxGamepad getDriverGamepad() {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -123,16 +123,10 @@ public class Robot extends TimedRobot {
      */
     @Override
     public void disabledPeriodic() {
-        Drivetrain.getInstance().getTopLeft().getDriveMotor().set(ControlMode.Disabled, 0);
-        Drivetrain.getInstance().getTopLeft().getAngleMotor().set(ControlMode.Disabled, 0);
+        Drivetrain.getInstance().applyToAllAngle((talon) -> talon.set(ControlMode.Disabled, 0));
+        Drivetrain.getInstance().applyToAllDrive((talon) -> talon.set(ControlMode.Disabled, 0));
 
-        Drivetrain.getInstance().getTopRight().getDriveMotor().set(ControlMode.Disabled, 0);
-        Drivetrain.getInstance().getTopRight().getAngleMotor().set(ControlMode.Disabled, 0);
-
-        Drivetrain.getInstance().getBackLeft().getDriveMotor().set(ControlMode.Disabled, 0);
-        Drivetrain.getInstance().getBackLeft().getAngleMotor().set(ControlMode.Disabled, 0);
-
-        Drivetrain.getInstance().getBackRight().getDriveMotor().set(ControlMode.Disabled, 0);
-        Drivetrain.getInstance().getBackRight().getAngleMotor().set(ControlMode.Disabled, 0);
+        Drivetrain.getInstance().applyToAllDrive((talon) -> talon.clearMotionProfileTrajectories());
+        Drivetrain.getInstance().applyToAllAngle((talon) -> talon.clearMotionProfileTrajectories());
     }
 }

--- a/src/main/java/frc/robot/commands/SwerveManual.java
+++ b/src/main/java/frc/robot/commands/SwerveManual.java
@@ -37,13 +37,10 @@ public class SwerveManual extends IndefiniteCommand {
     private static boolean pigeonFlag; //True if the Driver Right X input is non-zero
     private static double pigeonAngle;
     
-    private double prevTranslationAngle;
-    
     public SwerveManual() {
         requires(Drivetrain.getInstance());
         pigeonFlag = false;
         pigeonAngle = 0;
-        prevTranslationAngle = 0;
         prevPigeonHeading = 0;
         prevTime = System.currentTimeMillis();
     }
@@ -66,6 +63,7 @@ public class SwerveManual extends IndefiniteCommand {
         double turnMagnitude = MathUtil.mapJoystickOutput(OI.getInstance().getDriverGamepad().getRightX(), OI.XBOX_JOYSTICK_DEADBAND);
 
         double currentPigeonHeading = Drivetrain.getInstance().getPigeon().getFusedHeading();
+
         if(pigeonFlag && turnMagnitude == 0) { //If there was joystick input but now there is not
             long currentTime = System.currentTimeMillis();
             double deltaTime = (double)(currentTime - prevTime);
@@ -89,11 +87,6 @@ public class SwerveManual extends IndefiniteCommand {
         if(Drivetrain.getInstance().isFieldSensitive()) {
             translation.rotate(-Drivetrain.getInstance().getPigeon().getFusedHeading());
         }
-
-        // boolean invertSetpoint = Math.abs(translation.getAngle() - prevTranslationAngle) > 90;
-        // prevTranslationAngle = translation.getAngle();
-        // SmartDashboard.putBoolean("Joystick invertSetpoint", invertSetpoint);
-        // System.out.println(invertSetpoint);
 
         Vector topLeftRotation = new Vector(Drivetrain.DT_LENGTH, Drivetrain.DT_WIDTH);
         Vector topRightRotation = new Vector(Drivetrain.DT_LENGTH, -Drivetrain.DT_WIDTH);
@@ -124,11 +117,6 @@ public class SwerveManual extends IndefiniteCommand {
         sumBackRight.scale(1 / largestMag);
 
         Drivetrain.getInstance().setDrivetrain(sumTopLeft, sumTopRight, sumBackLeft, sumBackRight, IS_PERCENT_OUTPUT);
-
-        // if (turnMagnitude<=0.1&&translateX<=0.1&&translateY<=0.1)
-        // {
-        //     Drivetrain.getInstance().applyToAllAngle((angleMotor) -> angleMotor.set(ControlMode.PercentOutput, 0));
-        // }
     }
 
     public static double max4(double a, double b, double c, double d) {
@@ -138,7 +126,6 @@ public class SwerveManual extends IndefiniteCommand {
     @Override
     protected void end() {
         Drivetrain.getInstance().stopAllDrive();
-
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -89,19 +89,21 @@ public class Drivetrain extends Subsystem {
 
     private static final int MOTION_FRAME_PERIOD = 5;
   
-    public static final double MAX_DRIVE_VELOCITY = 5;
+    public static final double MAX_DRIVE_VELOCITY = 9;
+    public static final double MAX_DRIVE_ACCELERATION = 4;
+    public static final double MAX_DRIVE_JERK = 50;
     public static final double DRIVE_RAMP_RATE = 0.1;
     public static final double ANGLE_RAMP_RATE = 0.05;
     public static final double GEAR_RATIO = 6;
     
     /**
-     * Inches between both of the wheels on the front or back
+     * Meters between both of the wheels on the front or back
      */
-    public static final double DT_WIDTH = 16.5;
+    public static final double DT_WIDTH = 0.419; //16.5 in 
     /**
-     * Inches between both of the wheels on the left or right
+     * Meters between both of the wheels on the left or right
      */
-    public static final double DT_LENGTH = 20.6; 
+    public static final double DT_LENGTH = 0.523; //20.6 in
     
     public static final int TL_OFFSET = 2212;//1749;//2212-1749
     public static final int TR_OFFSET = 6730;//7638;
@@ -199,12 +201,10 @@ public class Drivetrain extends Subsystem {
      * 1. Subtract 90 degrees. 0 degrees on the Joysticks and desired Vectors points to the right (positive x axis)
      *    while 0 degrees on the robot points forward (positive y axis). The subtraction deals with this offset.
      * 2. Increase/Decrease the targetAngle by 360 degrees until it is within +- 180 degrees of the current angle
-     * 3. (Optional) Ensure the angle motor does not have to turn more than 90 degrees 
-     *    (if we need to turn 179 degrees, we can instead turn -1 degree and invert output)
      * 
      * @return The desired angle after all modifications
      */
-    public double convertAngle(SwerveModule module, double targetAngle) {
+    public static double convertAngle(SwerveModule module, double targetAngle) {
         //Step 1
         targetAngle -= 90; 
 
@@ -218,17 +218,7 @@ public class Drivetrain extends Subsystem {
             targetAngle -= 360;
         }
         
-        //Step 3
-        // if (Math.abs(currDegrees - targetAngle) > 90) {
-        //    module.invertOutput();
-        //    targetAngle += 180;
-        // }
-        // else if (currDegrees - targetAngle < -90) {
-        //     module.invertOutput();
-        //     targetAngle -= 180;
-        // }
-        
-        return (targetAngle);
+        return targetAngle;
     }
 
     /**

--- a/src/main/java/frc/robot/util/SwerveModule.java
+++ b/src/main/java/frc/robot/util/SwerveModule.java
@@ -131,12 +131,13 @@ public class SwerveModule {
         if(isPercentOutput) {
             driveMotor.set(ControlMode.PercentOutput, output);
         } else {
-            driveMotor.set(ControlMode.Velocity, Conversions.convert(SpeedUnit.FEET_PER_SECOND, output, SpeedUnit.ENCODER_UNITS)* Drivetrain.GEAR_RATIO);
+            driveMotor.set(ControlMode.Velocity, Conversions.convert(SpeedUnit.FEET_PER_SECOND, output, SpeedUnit.ENCODER_UNITS) * Drivetrain.GEAR_RATIO);
         }
     }
     
     public void setAngleAndDrive(double targetAngle, double output, boolean isPercentOutput) {
         boolean shouldReverse = Math.abs(targetAngle - getAngleDegrees()) > 90;
+        
         if (shouldReverse) {
             setDriveOutput(-output, isPercentOutput);
             if (targetAngle - getAngleDegrees() > 90) {


### PR DESCRIPTION
In addition to cleaning up errors in the Motion Profile Command, the most major change is how the Angle Stream's position values are calculated based on the heading of the original Trajectory. 

I also changed the WIDTH and LENGTH constants in Drivetrain to be in meters, since it cleans up the Motion Profile command and should not affect the rotation vector calculations in our manual command at all.

Everything else is just cleaning up and re-organizing the rest of the code.